### PR TITLE
Wrap mqtt message

### DIFF
--- a/mqtt.go
+++ b/mqtt.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	mqtt "github.com/clearblade/mqtt_parsing"
 	mqcli "github.com/clearblade/mqttclient"
+	"sync"
 )
 
 const (
@@ -62,30 +63,36 @@ func (d *DevClient) Publish(topic string, message []byte, qos int) error {
 	return publish(d.MQTTClient, topic, message, qos, d.getMessageId())
 }
 
-func (u *UserClient) Subscribe(topic string, qos int) (<-chan MqttMessage, error) {
+func (u *UserClient) Subscribe(topic string, qos int) (<-chan *MqttMessage, error) {
 	ch, err := subscribe(u.MQTTClient, topic, qos)
 	if err != nil {
 		return nil, err
 	} else {
-		return convertMqttMessage(ch), nil
+		out, ech := convertMqttMessage(ch)
+		u.addpipe(topic, ech)
+		return out, nil
 	}
 
 }
 
-func (d *DevClient) Subscribe(topic string, qos int) (<-chan MqttMessage, error) {
+func (d *DevClient) Subscribe(topic string, qos int) (<-chan *MqttMessage, error) {
 	ch, err := subscribe(d.MQTTClient, topic, qos)
 	if err != nil {
 		return nil, err
 	} else {
-		return convertMqttMessage(ch), nil
+		out, ech := convertMqttMessage(ch)
+		d.addpipe(topic, ech)
+		return out, nil
 	}
 }
 
 func (u *UserClient) Unsubscribe(topic string) error {
+	u.killpipe(topic)
 	return unsubscribe(u.MQTTClient, topic)
 }
 
 func (d *DevClient) Unsubscribe(topic string) error {
+	d.killpipe(topic)
 	return unsubscribe(d.MQTTClient, topic)
 }
 
@@ -157,22 +164,54 @@ func disconnect(c *mqcli.Client) error {
 }
 
 //TODO:have a way of keeping of when to kill these goroutines
-func convertMqttMessage(msg chan mqtt.Message) <-chan *MqttMessage {
-	mmc := make(chan MqttMessage, len(ch))
-	go func(pc <-chan mqtt.Message) {
-		for msg := range pc {
-			switch msg.(type) {
-			case *mqtt.Publish:
+func convertMqttMessage(msg <-chan mqtt.Message) (<-chan *MqttMessage, chan<- struct{}) {
+	mmc := make(chan *MqttMessage, len(msg))
+	ech := make(chan struct{}, 1)
+	go func(pc <-chan mqtt.Message, mc chan *MqttMessage, erch chan struct{}) {
+		//TODO: can we do this without the overhead of a goroutine?
+		for {
+			select {
+			case msg := <-pc:
 				pub, _ := msg.(*mqtt.Publish)
-				newmm := MqttMessage{
+				newmm := &MqttMessage{
 					Payload:   pub.Payload,
 					MessageId: int(pub.MessageId),
 					Topic:     pub.Topic.Whole,
 				}
-
-				mmc <- convertMqttMessage(msg)
+				mc <- newmm
+			case <-erch:
+				//close both channels in unsubscribe calls
+				return
 			}
 		}
-	}(ch)
-	return mmc
+	}(msg, mmc, ech)
+	return mmc, ech
+}
+
+type pipedict struct {
+	p      map[string]chan<- struct{}
+	pd_mut *sync.Mutex
+}
+
+func newpipedict() *pipedict {
+	return &pipedict{
+		pd_mut: new(sync.Mutex),
+		p:      make(map[string]chan<- struct{}),
+	}
+}
+
+func (pd *pipedict) addPipe(top string, ch chan<- struct{}) {
+	pd.pd_mut.Lock()
+	pd.p[top] = ch
+	pd.pd_mut.Unlock()
+}
+
+func (pd *pipedict) removePipe(top string) {
+	pd.pd_mut.Lock()
+	ech := pd.p[top]
+	delete(pd.p, top)
+	ech <- struct{}{}
+	pd.pd_mut.Unlock()
+	//do we close the other chan?
+	close(ech)
 }

--- a/utils.go
+++ b/utils.go
@@ -56,6 +56,7 @@ type cbClient interface {
 type UserClient struct {
 	UserToken    string
 	mrand        *rand.Rand
+	pipedict     *pipedict
 	MQTTClient   *mqttclient.Client
 	SystemKey    string
 	SystemSecret string
@@ -65,6 +66,7 @@ type UserClient struct {
 
 type DevClient struct {
 	DevToken   string
+	pipedict   *pipedict
 	mrand      *rand.Rand
 	MQTTClient *mqttclient.Client
 	Email      string
@@ -86,6 +88,7 @@ type CbResp struct {
 func NewUserClient(systemkey, systemsecret, email, password string) *UserClient {
 	return &UserClient{
 		UserToken:    "",
+		pipedict:     newpipedict(),
 		mrand:        rand.New(rand.NewSource(time.Now().UnixNano())),
 		MQTTClient:   nil,
 		SystemSecret: systemsecret,
@@ -98,6 +101,7 @@ func NewUserClient(systemkey, systemsecret, email, password string) *UserClient 
 func NewDevClient(email, password string) *DevClient {
 	return &DevClient{
 		DevToken:   "",
+		pipedict:   newpipedict(),
 		mrand:      rand.New(rand.NewSource(time.Now().UnixNano())),
 		MQTTClient: nil,
 		Email:      email,
@@ -127,6 +131,22 @@ func (u *UserClient) Logout() error {
 
 func (d *DevClient) Logout() error {
 	return logout(d)
+}
+
+func (u *UserClient) killpipe(top string) {
+	u.pipedict.removePipe(top)
+}
+
+func (d *DevClient) killpipe(top string) {
+	d.pipedict.removePipe(top)
+}
+
+func (u *UserClient) addpipe(top string, ech chan<- struct{}) {
+	u.pipedict.addPipe(top, ech)
+}
+
+func (d *DevClient) addpipe(top string, ech chan<- struct{}) {
+	d.pipedict.addPipe(top, ech)
 }
 
 //Below are some shared functions


### PR DESCRIPTION
@cwandrews There has been an offline request for a wrapper object around the mqtt Publish messages that should be coming off of the chan returned by a subscribe call. The reasons are 
1) Messy importing by library consumers. They have to import "github.com/clearblade/mqtt_parsing", in addition to the go-sdk. Sort of breaks abstraction.
2) We require doing run time type checks to make the library useful. 

What's here is basically a pipe. A goroutine sits on the channel, and unwraps the publish and sends it along to the outgoing channel.

What I don't like:
Keeping a dict of every subscription, spawning a goroutine for every subscription (in addition to goroutines layers down doing nearly identical work).

Alternatives:
Can we hoist the type from mqtt_parsing into this package? If yes, can we still use the same chan produced by the subscribe call in mqttclient? Am I having a brain-block and we can shuffle the values along without goroutines?

Impact: when this is merged, we'll have to update some internal apps. 
