### PR TITLE
Encode query vals

### DIFF
--- a/bucketcalls.go
+++ b/bucketcalls.go
@@ -1,8 +1,8 @@
 package GoSDK
 
-import "fmt"
-
+import (
 //"fmt"
+)
 
 const (
 	_BUCKET_SETS_PREAMBLE = "/api/v/4/bucket_sets/"
@@ -225,17 +225,14 @@ func readBucketSetFile(c cbClient, endpoint, box, relPath string) (string, error
 	queries := map[string]string{"box": box, "path": relPath}
 	creds, err := c.credentials()
 	if err != nil {
-		return "", fmt.Errorf("Credentials error: %w", err)
+		return "", err
 	}
 	resp, err := get(c, endpoint, queries, creds, nil)
+	resp, err = mapResponse(resp, err)
 	if err != nil {
-		return "", fmt.Errorf("Get error: %w", err)
+		return "", err
 	}
-	r, err := mapResponse(resp, err)
-	if err != nil {
-		return "", fmt.Errorf("Map response error - resp is: %v: %w", resp, err)
-	}
-	return r.Body.(string), nil
+	return resp.Body.(string), nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/bucketcalls.go
+++ b/bucketcalls.go
@@ -1,8 +1,8 @@
 package GoSDK
 
-import (
+import "fmt"
+
 //"fmt"
-)
 
 const (
 	_BUCKET_SETS_PREAMBLE = "/api/v/4/bucket_sets/"
@@ -225,14 +225,17 @@ func readBucketSetFile(c cbClient, endpoint, box, relPath string) (string, error
 	queries := map[string]string{"box": box, "path": relPath}
 	creds, err := c.credentials()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Credentials error: %w", err)
 	}
 	resp, err := get(c, endpoint, queries, creds, nil)
-	resp, err = mapResponse(resp, err)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Get error: %w", err)
 	}
-	return resp.Body.(string), nil
+	r, err := mapResponse(resp, err)
+	if err != nil {
+		return "", fmt.Errorf("Map response error - resp is: %v: %w", resp, err)
+	}
+	return r.Body.(string), nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/utils.go
+++ b/utils.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 
 	cbErr "github.com/clearblade/go-utils/errors"
@@ -21,10 +20,13 @@ import (
 
 var (
 	//CB_ADDR is the address of the ClearBlade Platform you are speaking with
-	CB_ADDR = "https://platform.clearblade.com"
+	// CB_ADDR = "https://platform.clearblade.com"
+	CB_ADDR = "https://localhost.clearblade.com"
 	//CB_MSG_ADDR is the messaging address you wish to speak to
-	CB_MSG_ADDR      = "platform.clearblade.com:1883"
-	CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"
+	// CB_MSG_ADDR      = "platform.clearblade.com:1883"
+	CB_MSG_ADDR = "localhost.clearblade.com:1883"
+	// CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"
+	CB_MSG_AUTH_ADDR = "localhost.clearblade.com:8905"
 
 	MTLS_PORT = "444"
 
@@ -937,6 +939,7 @@ func do(c cbClient, r *CbReq, creds [][]string) (*CbResp, error) {
 	if bodyToSend != nil {
 		req, reqErr = http.NewRequest(r.Method, url, bodyToSend)
 	} else {
+		fmt.Printf("URL: %s\n", url)
 		req, reqErr = http.NewRequest(r.Method, url, nil)
 	}
 	if reqErr != nil {
@@ -1070,11 +1073,11 @@ func deleteWithBody(c cbClient, endpoint string, body interface{}, heads [][]str
 }
 
 func query_to_string(query map[string]string) string {
-	qryStr := ""
+	qryVals := url.Values{}
 	for k, v := range query {
-		qryStr += k + "=" + v + "&"
+		qryVals.Set(k, v)
 	}
-	return strings.TrimSuffix(qryStr, "&")
+	return qryVals.Encode()
 }
 
 func checkForEdgeProxy(c cbClient, r *CbReq) {

--- a/utils.go
+++ b/utils.go
@@ -20,13 +20,10 @@ import (
 
 var (
 	//CB_ADDR is the address of the ClearBlade Platform you are speaking with
-	// CB_ADDR = "https://platform.clearblade.com"
-	CB_ADDR = "https://localhost.clearblade.com"
+	CB_ADDR = "https://platform.clearblade.com"
 	//CB_MSG_ADDR is the messaging address you wish to speak to
-	// CB_MSG_ADDR      = "platform.clearblade.com:1883"
-	CB_MSG_ADDR = "localhost.clearblade.com:1883"
-	// CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"
-	CB_MSG_AUTH_ADDR = "localhost.clearblade.com:8905"
+	CB_MSG_ADDR      = "platform.clearblade.com:1883"
+	CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"
 
 	MTLS_PORT = "444"
 
@@ -939,7 +936,6 @@ func do(c cbClient, r *CbReq, creds [][]string) (*CbResp, error) {
 	if bodyToSend != nil {
 		req, reqErr = http.NewRequest(r.Method, url, bodyToSend)
 	} else {
-		fmt.Printf("URL: %s\n", url)
 		req, reqErr = http.NewRequest(r.Method, url, nil)
 	}
 	if reqErr != nil {

--- a/utils.go
+++ b/utils.go
@@ -20,8 +20,7 @@ import (
 
 var (
 	//CB_ADDR is the address of the ClearBlade Platform you are speaking with
-	// CB_ADDR = "https://platform.clearblade.com"
-	CB_ADDR = "https://localhost.clearblade.com"
+	CB_ADDR = "https://platform.clearblade.com"
 	//CB_MSG_ADDR is the messaging address you wish to speak to
 	CB_MSG_ADDR      = "platform.clearblade.com:1883"
 	CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"

--- a/utils.go
+++ b/utils.go
@@ -20,10 +20,13 @@ import (
 
 var (
 	//CB_ADDR is the address of the ClearBlade Platform you are speaking with
-	CB_ADDR = "https://platform.clearblade.com"
+	// CB_ADDR = "https://platform.clearblade.com"
+	CB_ADDR = "https://localhost.clearblade.com"
 	//CB_MSG_ADDR is the messaging address you wish to speak to
-	CB_MSG_ADDR      = "platform.clearblade.com:1883"
-	CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"
+	// CB_MSG_ADDR      = "platform.clearblade.com:1883"
+	CB_MSG_ADDR = "localhost.clearblade.com:1883"
+	// CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"
+	CB_MSG_AUTH_ADDR = "localhost.clearblade.com:8905"
 
 	MTLS_PORT = "444"
 
@@ -936,6 +939,7 @@ func do(c cbClient, r *CbReq, creds [][]string) (*CbResp, error) {
 	if bodyToSend != nil {
 		req, reqErr = http.NewRequest(r.Method, url, bodyToSend)
 	} else {
+		fmt.Printf("URL: %s\n", url)
 		req, reqErr = http.NewRequest(r.Method, url, nil)
 	}
 	if reqErr != nil {

--- a/utils.go
+++ b/utils.go
@@ -23,10 +23,8 @@ var (
 	// CB_ADDR = "https://platform.clearblade.com"
 	CB_ADDR = "https://localhost.clearblade.com"
 	//CB_MSG_ADDR is the messaging address you wish to speak to
-	// CB_MSG_ADDR      = "platform.clearblade.com:1883"
-	CB_MSG_ADDR = "localhost.clearblade.com:1883"
-	// CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"
-	CB_MSG_AUTH_ADDR = "localhost.clearblade.com:8905"
+	CB_MSG_ADDR      = "platform.clearblade.com:1883"
+	CB_MSG_AUTH_ADDR = "platform.clearblade.com:8905"
 
 	MTLS_PORT = "444"
 
@@ -939,7 +937,6 @@ func do(c cbClient, r *CbReq, creds [][]string) (*CbResp, error) {
 	if bodyToSend != nil {
 		req, reqErr = http.NewRequest(r.Method, url, bodyToSend)
 	} else {
-		fmt.Printf("URL: %s\n", url)
 		req, reqErr = http.NewRequest(r.Method, url, nil)
 	}
 	if reqErr != nil {


### PR DESCRIPTION
I noticed we can't get bucketsets with spaces in the name from cb-cli. It's because we don't encode our query params.