### PR TITLE
Remove manual calls to query escape

### DIFF
--- a/datacalls.go
+++ b/datacalls.go
@@ -3,7 +3,6 @@ package GoSDK
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 )
 
 const (
@@ -165,7 +164,7 @@ func getDataByName(c cbClient, sysKey string, collectionName string, query *Quer
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -193,7 +192,7 @@ func getdata(c cbClient, collection_id string, query *Query) (map[string]interfa
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -222,7 +221,7 @@ func getdatatotal(c cbClient, collection_id string, query *Query) (map[string]in
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -251,7 +250,7 @@ func getdatatotalbyname(c cbClient, system_key, collection_name string, query *Q
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -476,7 +475,7 @@ func deletedata(c cbClient, collection_id string, query *Query) error {
 			return err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -799,7 +798,7 @@ func (d *DevClient) QueryContinuousAggregate(systemKey, collectionName, aggregat
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil

--- a/devcalls.go
+++ b/devcalls.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 )
 
@@ -250,7 +249,7 @@ func (d *DevClient) DeleteRootCACertificate(systemKey string, query *Query) erro
 	}
 	qry := map[string]string{
 		"system_key": systemKey,
-		"query":      url.QueryEscape(string(query_bytes)),
+		"query":      string(query_bytes),
 	}
 	_, err = delete(d, d.preamble()+"/systemmanagement/certificates", qry, creds, nil)
 	if err != nil {
@@ -403,7 +402,7 @@ func (d *DevClient) GetRolesWithQuery(SystemKey string, query *Query) ([]interfa
 		return nil, err
 	}
 	qry = map[string]string{
-		"query": url.QueryEscape(string(query_bytes)),
+		"query": string(query_bytes),
 	}
 	resp, err := get(d, d.preamble()+"/user/"+SystemKey+"/roles", qry, creds, nil)
 	if err != nil {
@@ -435,7 +434,7 @@ func (d *DevClient) GetRolesCount(SystemKey string, query *Query) (CountResp, er
 		return CountResp{Count: 0}, err
 	}
 	qry = map[string]string{
-		"query": url.QueryEscape(string(query_bytes)),
+		"query": string(query_bytes),
 	}
 	resp, err := get(d, d.preamble()+"/user/"+SystemKey+"/roles/count", qry, creds, nil)
 	if err != nil {
@@ -493,7 +492,7 @@ func (d *DevClient) GetRole(SystemKey, roleName string) (map[string]interface{},
 		return nil, err
 	}
 	qry = map[string]string{
-		"query": url.QueryEscape(string(query_bytes)),
+		"query": string(query_bytes),
 	}
 	resp, err := get(d, d.preamble()+"/user/"+SystemKey+"/roles", qry, creds, nil)
 	if err != nil {
@@ -663,7 +662,7 @@ func (d *DevClient) GetUserInfo(systemKey, email string) (map[string]interface{}
 		return nil, err
 	}
 	qry = map[string]string{
-		"query": url.QueryEscape(string(query_bytes)),
+		"query": string(query_bytes),
 	}
 	resp, err := get(d, d.preamble()+"/user/"+systemKey, qry, creds, nil)
 	if err != nil {

--- a/devicecalls.go
+++ b/devicecalls.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 )
 
 type KeyFormat int
@@ -97,7 +96,7 @@ func (d *DevClient) DeleteDevicePublicKey(systemKey, deviceName string, query *Q
 		return nil, err
 	}
 	qry := map[string]string{
-		"query": url.QueryEscape(string(query_bytes)),
+		"query": string(query_bytes),
 	}
 	_, err = delete(d, _DEVICE_PUBKEY_PREAMBLE+systemKey+"/"+deviceName, qry, creds, nil)
 	if err != nil {
@@ -569,7 +568,7 @@ func (d *DevClient) GetDeviceSession(systemKey string, query *Query) ([]interfac
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -597,7 +596,7 @@ func (d *DevClient) DeleteDeviceSession(systemKey string, query *Query) error {
 			return err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil

--- a/edgecalls.go
+++ b/edgecalls.go
@@ -3,7 +3,6 @@ package GoSDK
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -467,7 +466,7 @@ func (d *DevClient) DeleteEdgePublicKey(systemKey, edgeName string, query *Query
 		return nil, err
 	}
 	qry := map[string]string{
-		"query": url.QueryEscape(string(query_bytes)),
+		"query": string(query_bytes),
 	}
 	_, err = delete(d, _EDGES_PREAMBLE+"public_key/"+systemKey+"/"+edgeName, qry, creds, nil)
 	if err != nil {

--- a/metriccalls.go
+++ b/metriccalls.go
@@ -3,7 +3,6 @@ package GoSDK
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 )
 
 const (
@@ -117,7 +116,7 @@ func dbQueryToReqQuery(query *Query) (map[string]string, error) {
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(queryBytes)),
+			"query": string(queryBytes),
 		}
 	} else {
 		qry = nil

--- a/settingscalls.go
+++ b/settingscalls.go
@@ -3,7 +3,6 @@ package GoSDK
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 )
 
 //"fmt"
@@ -175,7 +174,7 @@ func (d *DevClient) GetRevokedCertificates(query *Query) ([]map[string]interface
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -204,7 +203,7 @@ func (d *DevClient) DeleteRevokedCertificates(query *Query) error {
 			return err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil

--- a/usercalls.go
+++ b/usercalls.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 )
 
 const (
@@ -253,7 +252,7 @@ func (d *DevClient) GetUserSession(systemKey string, query *Query) ([]interface{
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -281,7 +280,7 @@ func (d *DevClient) DeleteUserSession(systemKey string, query *Query) error {
 			return err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(query_bytes)),
+			"query": string(query_bytes),
 		}
 	} else {
 		qry = nil
@@ -381,7 +380,7 @@ func (u *UserClient) GetUserInfo(systemKey, email string) (map[string]interface{
 		return nil, err
 	}
 	qry = map[string]string{
-		"query": url.QueryEscape(string(query_bytes)),
+		"query": string(query_bytes),
 	}
 	resp, err := get(u, u.preamble(), qry, creds, nil)
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -1177,7 +1177,7 @@ func createQueryMap(query *Query) (map[string]string, error) {
 			return nil, err
 		}
 		qry = map[string]string{
-			"query": url.QueryEscape(string(queryBytes)),
+			"query": string(queryBytes),
 		}
 	} else {
 		qry = nil


### PR DESCRIPTION
The previous PR that I put up always encodes query params. We manually encode the params in certain places, which was causing it to be encoded twice. Removed those manual calls